### PR TITLE
fix: sanitize image filenames for writing to disk

### DIFF
--- a/R/download_view_filtered.R
+++ b/R/download_view_filtered.R
@@ -2,6 +2,11 @@
 #'
 #' Downloads PNG images of filtered Tableau views based on the provided dataframe containing filter columns and filter values.
 #'
+#' This function sanitizes filenames by removing forbidden characters.
+#' However, there is a risk of overwriting existing images if the only difference in filter values
+#' is the presence of forbidden characters.
+#' Users should be aware of this potential issue when using the function.
+#'
 #' @param tableau A list containing the Tableau authentication variables: `base_url`, `token`, `user_id`, and `site_id`.
 #' @param df Dataframe containing filter columns and filter values.
 #' @param view_id The ID of the view to download.
@@ -65,17 +70,17 @@ row_to_query <- function(row) {
   return(query)
 }
 
-#' Concat row to name
+#' Concat row to name with sanitization
 #'
 #' @param row row of dataframe
 #'
-#' @return namr of the row
+#' @return sanitized name of the row
 row_to_name <- function(row) {
   # Use paste to concatenate "vf_", column names, "=", and row values
   filter_strs <- paste0(as.character(row), collapse = "")
 
-  # Combine the filter strings with "&" and prepend "?"
-  query <- paste0((filter_strs))
+  # Sanitize the filename by removing forbidden characters
+  sanitized_name <- gsub("[<>:\"/\\|?*]", "_", filter_strs)  # Replace forbidden characters with underscore
 
-  return(query)
+  return(sanitized_name)
 }

--- a/man/download_filtered_tableau_image.Rd
+++ b/man/download_filtered_tableau_image.Rd
@@ -26,6 +26,12 @@ download_filtered_tableau_image(
 \description{
 Downloads PNG images of filtered Tableau views based on the provided dataframe containing filter columns and filter values.
 }
+\details{
+This function sanitizes filenames by removing forbidden characters.
+However, there is a risk of overwriting existing images if the only difference in filter values
+is the presence of forbidden characters.
+Users should be aware of this potential issue when using the function.
+}
 \seealso{
 Other Tableau REST API: 
 \code{\link{add_tags_to_view}()},

--- a/man/row_to_name.Rd
+++ b/man/row_to_name.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/download_view_filtered.R
 \name{row_to_name}
 \alias{row_to_name}
-\title{Concat row to name}
+\title{Concat row to name with sanitization}
 \usage{
 row_to_name(row)
 }
@@ -10,8 +10,8 @@ row_to_name(row)
 \item{row}{row of dataframe}
 }
 \value{
-namr of the row
+sanitized name of the row
 }
 \description{
-Concat row to name
+Concat row to name with sanitization
 }


### PR DESCRIPTION
# Pull Request Description

## Type of Change
<!-- Please select the appropriate type of change -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation update
- [ ] Other (please specify)

## Description of Changes
<!-- Provide a brief description of the changes made in this pull request -->

Before writing files to disk, replace special characters which are forbidden in filepaths, by an underscore.

## Related Issues
<!-- Link to any related issues using the GitHub issue syntax: #issue-number -->

See associated issue #10 



## Checklist
- [ ] I have tested these changes locally
- [x] I have updated the documentation accordingly
- [x] My code follows the project's coding standards
- [ ] I have added/updated tests to cover my changes (if applicable)
- [x] The code is accompanied by comments
- [x] I have linked this PR to relevant issues (if applicable)
